### PR TITLE
Fix validation error displaying.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,7 +101,7 @@ export const ColorInput = (props: ColorInputProps) => {
         onFocus={handleOpen}
         label={<FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />}
         error={!!(isTouched && error)}
-        helperText={helperText}
+        helperText={isTouched && error?.message ? error.message : helperText}
         className={className}
       />
       {show ? (


### PR DESCRIPTION
Validation errors are not displayed. So it is a fix for that.
![obraz](https://user-images.githubusercontent.com/1256986/229102876-7824af2f-11ba-4514-bbd6-0a8b508bda94.png)
Based on example of `useInput()` usage:
https://marmelab.com/react-admin/Inputs.html#the-useinput-hook